### PR TITLE
Create icon git-commit

### DIFF
--- a/svg/git-commit.svg
+++ b/svg/git-commit.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="234mm"
+   height="513mm"
+   viewBox="0 0 234 513"
+   version="1.1"
+   id="svg4605"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="git-commit.svg">
+  <defs
+     id="defs4599">
+    <linearGradient
+       id="linearGradient849"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop847" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient843"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop841" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient837"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop835" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient831"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop829" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35355339"
+     inkscape:cx="-46.761959"
+     inkscape:cy="869.24374"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1600"
+     inkscape:window-height="796"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata4602">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,216)"
+     style="display:inline">
+    <path
+       id="path12"
+       d="m 86.340304,-68.762402 0.979291,-112.843248 c 0.161871,-18.65239 13.791315,-33.77486 30.803545,-33.77486 17.01223,0 30.80357,15.12163 30.80357,33.77486 v 112.843248 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc"
+       style="display:inline;fill-rule:nonzero;stroke-width:1.00796914;paint-order:normal" />
+    <ellipse
+       style="fill-rule:nonzero;stroke-width:2.80652285;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:normal"
+       id="path9113"
+       cx="118.11168"
+       cy="39.908222"
+       rx="113.85683"
+       ry="109.58049" />
+    <path
+       id="path12-3"
+       d="m 148.92708,149.56523 -0.97929,112.84324 c -0.16187,18.65239 -13.79132,33.77486 -30.80354,33.77486 -17.01224,0 -30.803583,-15.12163 -30.803583,-33.77486 V 149.56523 Z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc"
+       style="display:inline;fill-rule:nonzero;stroke-width:1.00796914;paint-order:normal" />
+  </g>
+</svg>


### PR DESCRIPTION
I created this icon myself and publish it hereby under the MIT License. Please note that this icon looks different in browser/editor view than after the build with Node.js 12.13.0. 

First I tried to rotate and edit the icon git-commit from https://feathericons.com/?query=commit which is also published under the MIT License (https://github.com/feathericons/feather). But the Node.js build made the icon looks different than in the editor or the browser. I tried to fix that first by editing the icon via Inkscape and then by creating my own one. 

Now it looks like this in abapGit, which is fine by me:
![grafik](https://user-images.githubusercontent.com/45243391/68754892-e84b2d00-0607-11ea-80f8-bfca9435794e.png)

Whoever has the power to edit it the way it's meant to be - please do it! :)